### PR TITLE
build fixes & cleanup

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -6,10 +6,7 @@ TOP=$(shell pwd)
 DIRS=src
 
 all: pre
-	@if [ ! -f src/Makefile ]; then \
-	    (./RUNME;) \
-	fi
-	$(foreach var,$(DIRS), (cd $(var); $(MAKE) $@) ;)
+	$(foreach var,$(DIRS), $(MAKE) -C $(var) $@; )
 
 format:
 	$(foreach var,$(DIRS), (cd $(var); cp $(TOP)/.clang-format .) ;)
@@ -17,14 +14,12 @@ format:
 	$(foreach var,$(DIRS), (cd $(var); sh $(TOP)/build/format.sh do) ;)
 
 clean:
-	$(foreach var,$(DIRS), (cd $(var); $(MAKE) $@) ;)
+	$(foreach var,$(DIRS), $(MAKE) -C $(var) $@; )
 	/bin/rm -rf data/sounds
 	/bin/rm -rf data/gfx
-	/bin/rm -rf build.log
-	/bin/rm -rf appdata
 
-clobber: clean
-	$(foreach var,$(DIRS), (cd $(var); $(MAKE) $@) ;)
+clobber:
+	$(foreach var,$(DIRS), $(MAKE) -C $(var) $@; )
 
 .PHONY: all clean clobber format pre
 

--- a/build/Makefile
+++ b/build/Makefile
@@ -13,15 +13,17 @@ format:
 	$(foreach var,$(DIRS), (cd $(var); sh $(TOP)/build/tidy_source.sh do) ;)
 	$(foreach var,$(DIRS), (cd $(var); sh $(TOP)/build/format.sh do) ;)
 
-clean:
-	$(foreach var,$(DIRS), $(MAKE) -C $(var) $@; )
+clean_files:
 	/bin/rm -rf data/sounds/
 	/bin/rm -rf data/gfx/
 	/bin/rm -f build.log
 
-clobber:
+clean: clean_files
 	$(foreach var,$(DIRS), $(MAKE) -C $(var) $@; )
 
-.PHONY: all clean clobber format pre
+clobber: clean_files
+	$(foreach var,$(DIRS), $(MAKE) -C $(var) $@; )
+
+.PHONY: all clean_files clean clobber format pre
 
 .DEFAULT_GOAL := all

--- a/build/Makefile
+++ b/build/Makefile
@@ -15,8 +15,9 @@ format:
 
 clean:
 	$(foreach var,$(DIRS), $(MAKE) -C $(var) $@; )
-	/bin/rm -rf data/sounds
-	/bin/rm -rf data/gfx
+	/bin/rm -rf data/sounds/
+	/bin/rm -rf data/gfx/
+	/bin/rm -f build.log
 
 clobber:
 	$(foreach var,$(DIRS), $(MAKE) -C $(var) $@; )

--- a/src/Makefile
+++ b/src/Makefile
@@ -3,7 +3,7 @@ include ../build/Makefile.template
 NAME=yelindor
 BUILD_DIR=../.o
 
-TARGET_GAME=$(NAME)$(EXE)
+TARGET_GAME=../$(NAME)$(EXE)
 SRC_DIR=.
 
 #
@@ -13,34 +13,37 @@ SRC_DIR=.
 
 all: $(TARGET_GAME)
 
-SOURCES := $(wildcard *.cpp) $(wildcard */*.cpp) $(wildcard */*/*.cpp) $(wildcard *.S)
-OBJECTS :=\
-	$(addprefix $(BUILD_DIR)/,$(addsuffix .o,$(basename $(SOURCES))))
+# function to make object names from source files
+# (changes suffix to .o, encodes directory names so subdirectories in build dir aren't necessary)
+obj_name = $(addsuffix .o,$(subst /,__,$(subst ../,,$(basename $1))))
 
-DEP_FILES := $(OBJECTS:.o=.d)
+# recursively search all src/ subdirectories for cpp source files
+CPP_SOURCES := $(subst ./,,$(shell find $(SRC_DIR) -name \*.cpp))
+ASM_SOURCES := $(wildcard *.S)
+SOURCES := $(CPP_SOURCES) $(ASM_SOURCES)
+
+OBJECTS := $(call obj_name,$(SOURCES))
+OBJ_FILES := $(addprefix $(BUILD_DIR)/,$(OBJECTS))
+
+DEP_FILES := $(OBJ_FILES:.o=.d)
 DEP_FLAGS = -MMD -MP
 
-$(BUILD_DIR)/things/world: ; mkdir -p $(BUILD_DIR)/things/world
-$(OBJECTS): | $(BUILD_DIR)/things/world
-
-$(BUILD_DIR)/things/player: ; mkdir -p $(BUILD_DIR)/things/player
-$(OBJECTS): | $(BUILD_DIR)/things/player
-
-$(BUILD_DIR)/things/dungeon: ; mkdir -p $(BUILD_DIR)/things/dungeon
-$(OBJECTS): | $(BUILD_DIR)/things/dungeon
-
 $(BUILD_DIR): ; mkdir -p $(BUILD_DIR)
-$(OBJECTS): | $(BUILD_DIR)
+$(OBJ_FILES): | $(BUILD_DIR)
 
-$(BUILD_DIR)/%.o: %.cpp
-	$(CC) $(CFLAGS) $(DEP_FLAGS) -c -o $@ $<
+# custom compile command for each source file needed because object file
+# base names don't match source files that were in src/ subdirectories
+$(foreach x,$(CPP_SOURCES),\
+$(eval $(BUILD_DIR)/$(call obj_name,$x): $x ; $(CC) $(CFLAGS) $(DEP_FLAGS) -c -o $$@ $$<))
 
-$(BUILD_DIR)/%.o: %.S
-	$(CC) $(DEP_FLAGS) -c -o $@ $<
+$(foreach x,$(ASM_SOURCES),\
+$(eval $(BUILD_DIR)/$(call obj_name,$x): $x ; $(CC) $(DEP_FLAGS) -c -o $$@ $$<))
 
-$(TARGET_GAME): $(OBJECTS)
-	cd $(BUILD_DIR); $(CC) $(LDFLAGS) *.o */*/*.o $(LDLIBS) -o $(TARGET_GAME)
-	cp -f $(BUILD_DIR)/$(NAME)* ..
+
+# use file list instead of wildcard for link command so we don't accidentally
+# link with old object files for removed source files
+$(TARGET_GAME): $(OBJ_FILES)
+	cd $(BUILD_DIR); $(CC) $(LDFLAGS) $(OBJECTS) $(LDLIBS) -o $(TARGET_GAME)
 
 tidy:
 	for src in $(SOURCES) ; do \
@@ -52,9 +55,10 @@ tidy:
 .PHONY: style check-style tidy
 
 clean:
-	rm -f ../$(TARGET_GAME) ../stdout.txt ../stderr.txt
-	rm -f $(TARGET_GAME) stdout.txt stderr.txt
-	rm -rf $(BUILD_DIR)
+	rm -f $(TARGET_GAME) ../stdout.txt ../stderr.txt
+	@# safer delete of build dir instead of just 'rm -rf $(BUILD_DIR)'
+	rm -f $(BUILD_DIR)/*.[od]
+	@([ -d "$(BUILD_DIR)" ] && rmdir $(BUILD_DIR)) || true
 
 clobber: clean
 	rm -f ramdisk_data.cpp $(wildcard ramdisk_data*.S)


### PR DESCRIPTION
build/Makefile changes:
(1) don't call RUNME for missing src/Makefile since that file isn't created from a template in this project
(2) merged cd commands into $(MAKE) command where possible
(3) removed rm for appdata since it doesn't exist (yet?)
(4) reworked 'clobber' to not cause 'clean' target in 'src/Makefile' to be run twice

src/Makefile changes:
(1) don't always run binary link command for 'make all'
(2) recursively search all src/ subdirectories for cpp files
(3) directories in BUILD_DIR are no longer required to handle source files from src/ subdirectories
(4) binary is directly written to base directory instead of being copied out of BUILD_DIR
(5) link command has explicit list of object files instead of using a wildcard so old object files aren't accidentally included in linking
(6) safety changes for deleting of BUILD_DIR (unexpected files left in BUILD_DIR will now need to be manually removed)
